### PR TITLE
Add metadata.json to specify module dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -2,9 +2,10 @@
   "name": "dmase-wireguard",
   "version": "0.1.0",
   "author": "dmaes",
-  "summary": "",
+  "summary": "Puppet module to configure Wireguard",
   "license": "Apache-2.0",
-  "source": "",
+  "source": "https://github.com/dmaes/puppet-wireguard.git",
+  "project_page": "https://github.com/dmaes/puppet-wireguard.git",
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
@@ -19,19 +20,22 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7"
+        "7",
+        "8"
       ]
     },
     {
       "operatingsystem": "RedHat",
       "operatingsystemrelease": [
+        "7",
         "8"
       ]
     },
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "10"
+        "10",
+        "11"
       ]
     }
   ],

--- a/metadata.json
+++ b/metadata.json
@@ -1,0 +1,44 @@
+{
+  "name": "dmase-wireguard",
+  "version": "0.1.0",
+  "author": "dmaes",
+  "summary": "",
+  "license": "Apache-2.0",
+  "source": "",
+  "dependencies": [
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 4.24.0 < 8.1.0"
+    },
+    {
+      "name": "example42-network",
+      "version_requirement": ">= 3.0.1 <= 3.6.1"
+    }
+  ],
+  "operatingsystem_support": [
+    {
+      "operatingsystem": "CentOS",
+      "operatingsystemrelease": [
+        "7"
+      ]
+    },
+    {
+      "operatingsystem": "RedHat",
+      "operatingsystemrelease": [
+        "8"
+      ]
+    },
+    {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "10"
+      ]
+    }
+  ],
+  "requirements": [
+    {
+      "name": "puppet",
+      "version_requirement": ">= 6.21.0 < 8.0.0"
+    }
+  ]
+}


### PR DESCRIPTION
Currently using this module on my Debian machines but I was a bit confused trying to find out which Network module was being used in `interface.pp`. 

Hence a simple metadata file to remedy this :) 